### PR TITLE
Replace deprecated django function url with re_path

### DIFF
--- a/omero-openlink/omero_openlink/urls.py
+++ b/omero-openlink/omero_openlink/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     re_path(r'^deleteOpenLink/?',views.delete, name='openlink-delete'),
 
     #show debugoutput: replace in url "webclient" by "omero_openlink/debugoutput"
-    #url(r'^debugoutput/$',views.debugoutput,name='debugoutput'),
+    #re_path(r'^debugoutput/$',views.debugoutput,name='debugoutput'),
 
 
 ]

--- a/omero-openlink/omero_openlink/urls.py
+++ b/omero-openlink/omero_openlink/urls.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from django.conf.urls import url
+from django.urls import re_path 
 from . import views
 
 
@@ -8,9 +8,9 @@ urlpatterns = [
 
 
     # index 'home page' of the openlink app
-    url(r'^$', views.openlink, name='openlink_index'),
+    re_path(r'^$', views.openlink, name='openlink_index'),
 
-    url(r'^deleteOpenLink/?',views.delete, name='openlink-delete'),
+    re_path(r'^deleteOpenLink/?',views.delete, name='openlink-delete'),
 
     #show debugoutput: replace in url "webclient" by "omero_openlink/debugoutput"
     #url(r'^debugoutput/$',views.debugoutput,name='debugoutput'),


### PR DESCRIPTION
The newer versions of the OMERO.web (5.24) switched to django4.2. This breaks the current version of the plugin because the funcion `url` was deprecated and removed after django3. This causes an error because the function can no longer be imported, see [attached file](https://github.com/sukunis/OMERO.openlink/files/14097649/omero_web_error.txt).

The function was replaced with `re_path` which does exactly the same thing as the old `url` function (https://docs.djangoproject.com/en/3.1/ref/urls/#url). This change was tested with the latest version of OMERO.web (5.24) and is also compatible with the old versions (tested on 5.19 and 5.21 in docker) because the  `url` function  was already an alias of  `re_path` in django3.1 (https://docs.djangoproject.com/en/3.1/ref/urls/#url).