### PR TITLE
fix for small string issue

### DIFF
--- a/omero_openlink/scripts/omero/util_scripts/Create_OpenLink.py
+++ b/omero_openlink/scripts/omero/util_scripts/Create_OpenLink.py
@@ -69,7 +69,7 @@ NGINX_LOCATION= ''#'/openlink'
 URL = "%s://%s%s"%(TYPE_HTTP,SERVER_NAME,NGINX_LOCATION)
 
 OPENLINK_PATTERN='rn_*_'
-GET_SLOTNAME_PATTERN = '^rn_[A-Z,0-9]+_\d+_(.+)'
+GET_SLOTNAME_PATTERN = r'^rn_[A-Z,0-9]+_\d+_(.+)'
 CURL_FILE="batch_download.curl"
 CONTENT_FILE="content.json"
 CURL_PATTERN='create-dirs\n output="%s%s%s"\n continue-at -\n url="%s/%s/%s"'


### PR DESCRIPTION
got the error:
```
/home/omero-server/omero/tmp/omero_omero-server/2372/process7lw95yxy.dir/./script:72: SyntaxWarning: invalid escape sequence '\d'
  GET_SLOTNAME_PATTERN = '^rn_[A-Z,0-9]+_\d+_(.+)'
 ```

a simple "raw" string solves this