### PR TITLE
added NGINX location setting to fix bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,8 @@ Additional configuration settings:
     $omero config set omero.web.openlink.servername 'demo.openmicroscopy.org'
     # http or https
     $omero config set omero.web.openlink.type_http 'https'
+    # nginx location for openlink data, here as example /openlink; would result in the url https://demo.openmicroscopy.org/openlink
+    $omero config set omero.web.openlink.nginx_location '/openlink'
 
 Reload your system and restart the OMERO.web server:
 

--- a/omero_openlink/openlink_settings.py
+++ b/omero_openlink/openlink_settings.py
@@ -8,12 +8,16 @@ def str_not_empty(o):
         raise ValueError('Invalid empty value')
     return s
 
+def str_allow_empty(o):
+    return str(o)
+
 
 OPENLINK_SETTINGS_MAPPINGS = {
     'omero.web.openlink.dir': ['OPENLINK_DIR', '', str_not_empty, None],
     # $ omero config set omero.web.openlink.dir '{""}'
     'omero.web.openlink.servername': ['SERVER_NAME', '', str_not_empty, None],
-    'omero.web.openlink.type_http': ['TYPE_HTTP', '', str_not_empty, None]
+    'omero.web.openlink.type_http': ['TYPE_HTTP', '', str_not_empty, None],
+    'omero.web.openlink.nginx_location': ['NGINX_LOCATION', '', str_allow_empty, None]
 }
 
 process_custom_settings(sys.modules[__name__], 'OPENLINK_SETTINGS_MAPPINGS')

--- a/omero_openlink/views.py
+++ b/omero_openlink/views.py
@@ -33,6 +33,15 @@ OPENLINK_DIR = openlink_settings.OPENLINK_DIR.rstrip("/")
 TYPE_HTTP = openlink_settings.TYPE_HTTP
 SERVER_NAME = f'{TYPE_HTTP}://{openlink_settings.SERVER_NAME}'.rstrip("/")
 
+# Optional URL prefix for nginx location, e.g. "/openlink"
+_NGINX_LOCATION = getattr(openlink_settings, "NGINX_LOCATION", "")
+_NGINX_LOCATION = (_NGINX_LOCATION or "").strip()
+if _NGINX_LOCATION:
+    if not _NGINX_LOCATION.startswith("/"):
+        _NGINX_LOCATION = f"/{_NGINX_LOCATION}"
+    _NGINX_LOCATION = _NGINX_LOCATION.rstrip("/")
+BASE_URL = f"{SERVER_NAME}{_NGINX_LOCATION}"
+
 
 CMD_CURL = "curl -s %s/%s/%s | curl -K-"
 CONTENT_FILE = "content.json"
@@ -45,7 +54,9 @@ SKIP_FILES = [CONTENT_FILE, CURL_FILE]
 def debugoutput(request, conn=None, **kwargs):
     data = [{
         'OpenLink Dir': OPENLINK_DIR,
-        'Server Name': SERVER_NAME
+        'Server Name': SERVER_NAME,
+        'Nginx Location': _NGINX_LOCATION,
+        'Base URL': BASE_URL
     }]
     # test openlink directory access
     if os.path.exists(OPENLINK_DIR):
@@ -149,9 +160,9 @@ def openlink(request, conn=None, **kwargs):
                     data = {'date': thisDate, 'area': areaName,
                             'timestamp': timestamp,
                             'hashname': os.path.basename(p),
-                            'url': f"{SERVER_NAME}/{os.path.basename(p)}/",
+                            'url': f"{BASE_URL}/{os.path.basename(p)}/",
                             'cmd': CMD_CURL % (
-                                SERVER_NAME,
+                                BASE_URL,
                                 os.path.basename(p).replace(" ", "%20"),
                                 CURL_FILE),
                             'size': filesizeformat(get_area_size(p))


### PR DESCRIPTION
I was running into issues, as the URL in the Web view right hand panel "OpenLink" Tab was always missing the `/openlink`.
E.g. `curl -s https://omero.nfdi4bioimage.de/rn_8BVNA0Q3F2GV_2_test_03/batch_download.curl | curl -K-` instead of `curl -s https://omero.nfdi4bioimage.de/openlink/rn_8BVNA0Q3F2GV_2_test_03/batch_download.curl | curl -K-`
And the Hyperlink behind the name of the Area had the same issue.
Implemented the new config setting `omero.web.openlink.nginx_location` to be used in `views.py`